### PR TITLE
Improve verification error handling

### DIFF
--- a/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/Chain.kt
+++ b/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/Chain.kt
@@ -73,10 +73,12 @@ class Chain(
             cbor = cwtService.decode(cwt, verificationResult)
             schemaValidationService.validate(cbor, verificationResult)
             eudgc = cborService.decode(cbor, verificationResult)
-        } catch (t: Throwable) {
+        } catch (e: VerificationException) {
+            verificationResult.error = e.error
+            verificationResult.errorMessage = e.message
             Napier.w(
-                message = t.message ?: "Decode Chain error",
-                throwable = if (globalLogLevel == Napier.Level.VERBOSE) t else null,
+                message = e.message ?: "Decode Chain error",
+                throwable = if (globalLogLevel == Napier.Level.VERBOSE) e else null,
                 tag = logTag
             )
         }

--- a/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/VerificationException.kt
+++ b/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/VerificationException.kt
@@ -1,0 +1,7 @@
+package ehn.techiop.hcert.kotlin.chain
+
+class VerificationException(
+    val error: Error,
+    message: String? = null,
+    cause: Throwable? = null
+) : Exception(message, cause)

--- a/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/VerificationResult.kt
+++ b/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/VerificationResult.kt
@@ -49,11 +49,11 @@ class VerificationResult {
      * Holds the error, if any occurred
      */
     var error: Error? = null
-        get() = field
-        set(value) {
-            if (field == null)
-                field = value
-        }
+
+    /**
+     * Optional message with details about the error, if any occurred
+     */
+    var errorMessage: String? = null
 
     override fun toString(): String {
         return "VerificationResult(" +
@@ -64,7 +64,8 @@ class VerificationResult {
                 "certificateValidUntil=$certificateValidUntil, " +
                 "certificateValidContent=$certificateValidContent, " +
                 "content=$content, " +
-                "error=$error" +
+                "error=$error, " +
+                "errorMessage=$errorMessage" +
                 ")"
     }
 

--- a/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/impl/DefaultBase45Service.kt
+++ b/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/impl/DefaultBase45Service.kt
@@ -2,6 +2,7 @@ package ehn.techiop.hcert.kotlin.chain.impl
 
 import ehn.techiop.hcert.kotlin.chain.Base45Service
 import ehn.techiop.hcert.kotlin.chain.Error
+import ehn.techiop.hcert.kotlin.chain.VerificationException
 import ehn.techiop.hcert.kotlin.chain.VerificationResult
 import ehn.techiop.hcert.kotlin.chain.common.Base45Encoder
 
@@ -19,9 +20,7 @@ open class DefaultBase45Service : Base45Service {
         try {
             return encoder.decode(input)
         } catch (e: Throwable) {
-            throw e.also {
-                verificationResult.error = Error.BASE_45_DECODING_FAILED
-            }
+            throw VerificationException(Error.BASE_45_DECODING_FAILED, cause = e)
         }
     }
 

--- a/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/impl/DefaultCborService.kt
+++ b/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/impl/DefaultCborService.kt
@@ -2,6 +2,7 @@ package ehn.techiop.hcert.kotlin.chain.impl
 
 import ehn.techiop.hcert.kotlin.chain.CborService
 import ehn.techiop.hcert.kotlin.chain.Error
+import ehn.techiop.hcert.kotlin.chain.VerificationException
 import ehn.techiop.hcert.kotlin.chain.VerificationResult
 import ehn.techiop.hcert.kotlin.data.GreenCertificate
 import ehn.techiop.hcert.kotlin.trust.ContentType
@@ -14,38 +15,31 @@ open class DefaultCborService : CborService {
     override fun encode(input: GreenCertificate) = Cbor.encodeToByteArray(input)
 
     override fun decode(input: ByteArray, verificationResult: VerificationResult): GreenCertificate? {
-        try {
+        val result = try {
             // TODO Remove "ignoreUnknownKeys", once everything is up to date with schema 1.2.1
-            val result = Cbor { ignoreUnknownKeys = true }.decodeFromByteArray<GreenCertificate>(input)
-            if (result.tests?.filterNotNull()?.isNotEmpty() == true) {
-                verificationResult.content.add(ContentType.TEST)
-                if (!verificationResult.certificateValidContent.contains(ContentType.TEST)) {
-                    throw Throwable("Type Test not valid").also {
-                        verificationResult.error = Error.UNSUITABLE_PUBLIC_KEY_TYPE
-                    }
-                }
-            }
-            if (result.vaccinations?.filterNotNull()?.isNotEmpty() == true) {
-                verificationResult.content.add(ContentType.VACCINATION)
-                if (!verificationResult.certificateValidContent.contains(ContentType.VACCINATION)) {
-                    throw Throwable("Type Vaccination not valid").also {
-                        verificationResult.error = Error.UNSUITABLE_PUBLIC_KEY_TYPE
-                    }
-                }
-            }
-            if (result.recoveryStatements?.filterNotNull()?.isNotEmpty() == true) {
-                verificationResult.content.add(ContentType.RECOVERY)
-                if (!verificationResult.certificateValidContent.contains(ContentType.RECOVERY)) {
-                    throw Throwable("Type Recovery not valid").also {
-                        verificationResult.error = Error.UNSUITABLE_PUBLIC_KEY_TYPE
-                    }
-                }
-            }
-            return result
+            Cbor { ignoreUnknownKeys = true }.decodeFromByteArray<GreenCertificate>(input)
         } catch (e: Throwable) {
-            throw e.also {
-                verificationResult.error = Error.CBOR_DESERIALIZATION_FAILED
-            }
+            throw VerificationException(Error.CBOR_DESERIALIZATION_FAILED, e.message, e)
         }
+
+        if (result.tests?.filterNotNull()?.isNotEmpty() == true) {
+            verificationResult.content.add(ContentType.TEST)
+            if (!verificationResult.certificateValidContent.contains(ContentType.TEST))
+                throw VerificationException(Error.UNSUITABLE_PUBLIC_KEY_TYPE, "Type Test not valid")
+        }
+
+        if (result.vaccinations?.filterNotNull()?.isNotEmpty() == true) {
+            verificationResult.content.add(ContentType.VACCINATION)
+            if (!verificationResult.certificateValidContent.contains(ContentType.VACCINATION))
+                throw VerificationException(Error.UNSUITABLE_PUBLIC_KEY_TYPE, "Type Vaccination not valid")
+        }
+
+        if (result.recoveryStatements?.filterNotNull()?.isNotEmpty() == true) {
+            verificationResult.content.add(ContentType.RECOVERY)
+            if (!verificationResult.certificateValidContent.contains(ContentType.RECOVERY))
+                throw VerificationException(Error.UNSUITABLE_PUBLIC_KEY_TYPE, "Type Recovery not valid")
+        }
+
+        return result
     }
 }

--- a/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/impl/DefaultCompressorService.kt
+++ b/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/impl/DefaultCompressorService.kt
@@ -2,6 +2,7 @@ package ehn.techiop.hcert.kotlin.chain.impl
 
 import ehn.techiop.hcert.kotlin.chain.CompressorService
 import ehn.techiop.hcert.kotlin.chain.Error
+import ehn.techiop.hcert.kotlin.chain.VerificationException
 import ehn.techiop.hcert.kotlin.chain.VerificationResult
 
 /**
@@ -25,9 +26,7 @@ open class DefaultCompressorService(private val level: Int = 9) : CompressorServ
         try {
             return adapter.decode(input)
         } catch (e: Throwable) {
-            throw e.also {
-                verificationResult.error = Error.DECOMPRESSION_FAILED
-            }
+            throw VerificationException(Error.DECOMPRESSION_FAILED, cause = e)
         }
     }
 

--- a/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/impl/DefaultContextIdentifierService.kt
+++ b/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/impl/DefaultContextIdentifierService.kt
@@ -2,6 +2,7 @@ package ehn.techiop.hcert.kotlin.chain.impl
 
 import ehn.techiop.hcert.kotlin.chain.ContextIdentifierService
 import ehn.techiop.hcert.kotlin.chain.Error
+import ehn.techiop.hcert.kotlin.chain.VerificationException
 import ehn.techiop.hcert.kotlin.chain.VerificationResult
 
 /**
@@ -15,9 +16,7 @@ open class DefaultContextIdentifierService(private val prefix: String = "HC1:") 
 
     override fun decode(input: String, verificationResult: VerificationResult) = when {
         input.startsWith(prefix) -> input.drop(prefix.length)
-        else -> throw Throwable("No context prefix '$prefix'").also {
-            verificationResult.error = Error.INVALID_SCHEME_PREFIX
-        }
+        else -> throw VerificationException(Error.INVALID_SCHEME_PREFIX, "No context prefix '$prefix'")
     }
 
 }

--- a/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/impl/DefaultCoseService.kt
+++ b/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/impl/DefaultCoseService.kt
@@ -1,9 +1,6 @@
 package ehn.techiop.hcert.kotlin.chain.impl
 
-import ehn.techiop.hcert.kotlin.chain.CoseService
-import ehn.techiop.hcert.kotlin.chain.CryptoService
-import ehn.techiop.hcert.kotlin.chain.Error
-import ehn.techiop.hcert.kotlin.chain.VerificationResult
+import ehn.techiop.hcert.kotlin.chain.*
 import ehn.techiop.hcert.kotlin.crypto.CoseHeaderKeys
 import ehn.techiop.hcert.kotlin.trust.CoseAdapter
 import ehn.techiop.hcert.kotlin.trust.CoseCreationAdapter
@@ -24,26 +21,22 @@ open class DefaultCoseService(private val cryptoService: CryptoService) : CoseSe
     }
 
     override fun decode(input: ByteArray, verificationResult: VerificationResult): ByteArray {
-        try {
-            val coseAdapter = CoseAdapter(strippedInput(input))
-            val kid = coseAdapter.getProtectedAttributeByteArray(CoseHeaderKeys.KID.intVal)
-                ?: coseAdapter.getUnprotectedAttributeByteArray(CoseHeaderKeys.KID.intVal)
-                ?: throw IllegalArgumentException("KID not found").also {
-                    verificationResult.error = Error.KEY_NOT_IN_TRUST_LIST
-                }
-            //val algorithm = coseAdapter.getProtectedAttributeInt(CoseHeaderKeys.Algorithm.value)
-            // TODO is the algorithm relevant?
-            if (!coseAdapter.validate(kid, cryptoService, verificationResult)) {
-                throw IllegalArgumentException("Not validated").also {
-                    verificationResult.error = Error.SIGNATURE_INVALID
-                }
-            }
-            return coseAdapter.getContent()
+        val coseAdapter = try {
+            CoseAdapter(strippedInput(input))
         } catch (e: Throwable) {
-            throw e.also {
-                verificationResult.error = Error.SIGNATURE_INVALID
-            }
+            throw VerificationException(Error.SIGNATURE_INVALID, e.message, e)
         }
+
+        val kid = coseAdapter.getProtectedAttributeByteArray(CoseHeaderKeys.KID.intVal)
+            ?: coseAdapter.getUnprotectedAttributeByteArray(CoseHeaderKeys.KID.intVal)
+            ?: throw VerificationException(Error.KEY_NOT_IN_TRUST_LIST, "KID not found")
+
+        //val algorithm = coseAdapter.getProtectedAttributeInt(CoseHeaderKeys.Algorithm.value)
+        // TODO is the algorithm relevant?
+        if (!coseAdapter.validate(kid, cryptoService, verificationResult))
+            throw throw VerificationException(Error.SIGNATURE_INVALID, "Not validated")
+
+        return coseAdapter.getContent()
     }
 
     // Input may be tagged as a CWT and a Sign1

--- a/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/impl/DefaultCwtService.kt
+++ b/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/impl/DefaultCwtService.kt
@@ -2,6 +2,7 @@ package ehn.techiop.hcert.kotlin.chain.impl
 
 import ehn.techiop.hcert.kotlin.chain.CwtService
 import ehn.techiop.hcert.kotlin.chain.Error
+import ehn.techiop.hcert.kotlin.chain.VerificationException
 import ehn.techiop.hcert.kotlin.chain.VerificationResult
 import ehn.techiop.hcert.kotlin.crypto.CwtHeaderKeys
 import ehn.techiop.hcert.kotlin.trust.CwtAdapter
@@ -37,37 +38,27 @@ open class DefaultCwtService constructor(
             map.getString(CwtHeaderKeys.ISSUER.intVal)?.let {
                 verificationResult.issuer = it
             }
+
             map.getNumber(CwtHeaderKeys.ISSUED_AT.intVal)?.let {
                 val issuedAt = Instant.fromEpochSeconds(it.toLong())
                 verificationResult.issuedAt = issuedAt
                 verificationResult.certificateValidFrom?.let { certValidFrom ->
-                    if (issuedAt < certValidFrom) {
-                        throw Throwable("issuedAt<certValidFrom").also {
-                            verificationResult.error = Error.CWT_EXPIRED
-                        }
-                    }
+                    if (issuedAt < certValidFrom)
+                        throw VerificationException(Error.CWT_EXPIRED, "issuedAt<certValidFrom")
                 }
-                if (issuedAt > clock.now()) {
-                    throw Throwable("issuedAt>clock.now()").also {
-                        verificationResult.error = Error.CWT_EXPIRED
-                    }
-                }
+                if (issuedAt > clock.now())
+                    throw VerificationException(Error.CWT_EXPIRED, "issuedAt>clock.now()")
             }
+
             map.getNumber(CwtHeaderKeys.EXPIRATION.intVal)?.let {
                 val expirationTime = Instant.fromEpochSeconds(it.toLong())
                 verificationResult.expirationTime = expirationTime
                 verificationResult.certificateValidUntil?.let { certValidUntil ->
-                    if (expirationTime > certValidUntil) {
-                        throw Throwable("expirationTime>certValidUntil").also {
-                            verificationResult.error = Error.CWT_EXPIRED
-                        }
-                    }
+                    if (expirationTime > certValidUntil)
+                        throw VerificationException(Error.CWT_EXPIRED, "expirationTime>certValidUntil")
                 }
-                if (expirationTime < clock.now()) {
-                    throw Throwable("expirationTime<clock.now()").also {
-                        verificationResult.error = Error.CWT_EXPIRED
-                    }
-                }
+                if (expirationTime < clock.now())
+                    throw VerificationException(Error.CWT_EXPIRED, "expirationTime<clock.now()")
             }
 
             map.getMap(CwtHeaderKeys.HCERT.intVal)?.let { hcert ->
@@ -75,11 +66,12 @@ open class DefaultCwtService constructor(
                     return eudgcV1.encoded()
                 }
             }
-            throw Throwable("CWT contains no HCERT or EUDGC")
+
+            throw VerificationException(Error.CBOR_DESERIALIZATION_FAILED, "CWT contains no HCERT or EUDGC")
+        } catch (e: VerificationException) {
+            throw e
         } catch (e: Throwable) {
-            throw e.also {
-                verificationResult.error = Error.CBOR_DESERIALIZATION_FAILED
-            }
+            throw VerificationException(Error.CBOR_DESERIALIZATION_FAILED, e.message, e)
         }
     }
 

--- a/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/impl/PrefilledCertificateRepository.kt
+++ b/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/impl/PrefilledCertificateRepository.kt
@@ -2,6 +2,7 @@ package ehn.techiop.hcert.kotlin.chain.impl
 
 import ehn.techiop.hcert.kotlin.chain.CertificateRepository
 import ehn.techiop.hcert.kotlin.chain.Error
+import ehn.techiop.hcert.kotlin.chain.VerificationException
 import ehn.techiop.hcert.kotlin.chain.VerificationResult
 import ehn.techiop.hcert.kotlin.crypto.CertificateAdapter
 
@@ -26,9 +27,9 @@ class PrefilledCertificateRepository : CertificateRepository {
         verificationResult: VerificationResult
     ): List<CertificateAdapter> {
         val certList = list.filter { it.kid contentEquals kid }
-        if (certList.isEmpty()) throw IllegalArgumentException("kid").also {
-            verificationResult.error = Error.KEY_NOT_IN_TRUST_LIST
-        }
+        if (certList.isEmpty())
+            throw VerificationException(Error.KEY_NOT_IN_TRUST_LIST, "kid not found")
+
         return certList
     }
 

--- a/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/impl/RandomEcKeyCryptoService.kt
+++ b/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/impl/RandomEcKeyCryptoService.kt
@@ -1,9 +1,6 @@
 package ehn.techiop.hcert.kotlin.chain.impl
 
-import ehn.techiop.hcert.kotlin.chain.CryptoService
-import ehn.techiop.hcert.kotlin.chain.Error
-import ehn.techiop.hcert.kotlin.chain.VerificationResult
-import ehn.techiop.hcert.kotlin.chain.asBase64
+import ehn.techiop.hcert.kotlin.chain.*
 import ehn.techiop.hcert.kotlin.chain.common.PkiUtils
 import ehn.techiop.hcert.kotlin.crypto.CertificateAdapter
 import ehn.techiop.hcert.kotlin.crypto.CoseHeaderKeys
@@ -44,9 +41,9 @@ class RandomEcKeyCryptoService constructor(
     override fun getCborSigningKey() = cryptoAdapter.privateKey
 
     override fun getCborVerificationKey(kid: ByteArray, verificationResult: VerificationResult): PubKey {
-        if (!(keyId contentEquals kid)) throw IllegalArgumentException("kid not known: $kid").also {
-            verificationResult.error = Error.KEY_NOT_IN_TRUST_LIST
-        }
+        if (!(keyId contentEquals kid))
+            throw VerificationException(Error.KEY_NOT_IN_TRUST_LIST, "kid not known: $kid")
+
         verificationResult.setCertificateData(certificate)
         return cryptoAdapter.publicKey
     }

--- a/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/impl/RandomRsaKeyCryptoService.kt
+++ b/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/impl/RandomRsaKeyCryptoService.kt
@@ -1,9 +1,6 @@
 package ehn.techiop.hcert.kotlin.chain.impl
 
-import ehn.techiop.hcert.kotlin.chain.CryptoService
-import ehn.techiop.hcert.kotlin.chain.Error
-import ehn.techiop.hcert.kotlin.chain.VerificationResult
-import ehn.techiop.hcert.kotlin.chain.asBase64
+import ehn.techiop.hcert.kotlin.chain.*
 import ehn.techiop.hcert.kotlin.chain.common.PkiUtils
 import ehn.techiop.hcert.kotlin.crypto.CertificateAdapter
 import ehn.techiop.hcert.kotlin.crypto.CoseHeaderKeys
@@ -40,9 +37,9 @@ class RandomRsaKeyCryptoService constructor(
     override fun getCborSigningKey() = cryptoAdapter.privateKey
 
     override fun getCborVerificationKey(kid: ByteArray, verificationResult: VerificationResult): PubKey {
-        if (!(keyId contentEquals kid)) throw IllegalArgumentException("kid not known: $kid").also {
-            verificationResult.error = Error.KEY_NOT_IN_TRUST_LIST
-        }
+        if (!(keyId contentEquals kid))
+            throw VerificationException(Error.KEY_NOT_IN_TRUST_LIST, "kid not known: $kid")
+
         verificationResult.setCertificateData(certificate)
         return cryptoAdapter.publicKey
     }

--- a/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/impl/TrustListCertificateRepository.kt
+++ b/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/impl/TrustListCertificateRepository.kt
@@ -2,6 +2,7 @@ package ehn.techiop.hcert.kotlin.chain.impl
 
 import ehn.techiop.hcert.kotlin.chain.CertificateRepository
 import ehn.techiop.hcert.kotlin.chain.Error
+import ehn.techiop.hcert.kotlin.chain.VerificationException
 import ehn.techiop.hcert.kotlin.chain.VerificationResult
 import ehn.techiop.hcert.kotlin.crypto.CertificateAdapter
 import ehn.techiop.hcert.kotlin.trust.TrustListDecodeService
@@ -22,9 +23,9 @@ class TrustListCertificateRepository(
         verificationResult: VerificationResult
     ): List<CertificateAdapter> {
         val certList = list.filter { it.kid contentEquals kid }
-        if (certList.isEmpty()) throw IllegalArgumentException("kid").also {
-            verificationResult.error = Error.KEY_NOT_IN_TRUST_LIST
-        }
+        if (certList.isEmpty())
+            throw VerificationException(Error.KEY_NOT_IN_TRUST_LIST, "kid not found")
+
         return certList.map { it.toCertificateAdapter() }
     }
 

--- a/src/jsMain/kotlin/ehn/techiop/hcert/kotlin/chain/impl/FileBasedCryptoService.kt
+++ b/src/jsMain/kotlin/ehn/techiop/hcert/kotlin/chain/impl/FileBasedCryptoService.kt
@@ -3,12 +3,7 @@ package ehn.techiop.hcert.kotlin.chain.impl
 import Asn1js.Sequence
 import Asn1js.fromBER
 import Buffer
-import ehn.techiop.hcert.kotlin.chain.CryptoService
-import ehn.techiop.hcert.kotlin.chain.Error
-import ehn.techiop.hcert.kotlin.chain.VerificationResult
-import ehn.techiop.hcert.kotlin.chain.asBase64
-import ehn.techiop.hcert.kotlin.chain.fromBase64
-import ehn.techiop.hcert.kotlin.chain.toByteArray
+import ehn.techiop.hcert.kotlin.chain.*
 import ehn.techiop.hcert.kotlin.crypto.CertificateAdapter
 import ehn.techiop.hcert.kotlin.crypto.CoseHeaderKeys
 import ehn.techiop.hcert.kotlin.crypto.CwtAlgorithm
@@ -81,9 +76,9 @@ actual class FileBasedCryptoService actual constructor(pemEncodedPrivateKey: Str
         kid: ByteArray,
         verificationResult: VerificationResult
     ): PubKey {
-        if (!(keyId contentEquals kid)) throw IllegalArgumentException("kid not known: $kid").also {
-            verificationResult.error = Error.KEY_NOT_IN_TRUST_LIST
-        }
+        if (!(keyId contentEquals kid))
+            throw VerificationException(Error.KEY_NOT_IN_TRUST_LIST, "kid not known: $kid")
+
         verificationResult.setCertificateData(certificate)
         return publicKey
     }

--- a/src/jvmMain/kotlin/ehn/techiop/hcert/kotlin/chain/impl/DefaultSchemaValidationService.kt
+++ b/src/jvmMain/kotlin/ehn/techiop/hcert/kotlin/chain/impl/DefaultSchemaValidationService.kt
@@ -3,6 +3,7 @@ package ehn.techiop.hcert.kotlin.chain.impl
 import com.upokecenter.cbor.CBORObject
 import ehn.techiop.hcert.kotlin.chain.Error
 import ehn.techiop.hcert.kotlin.chain.SchemaValidationService
+import ehn.techiop.hcert.kotlin.chain.VerificationException
 import ehn.techiop.hcert.kotlin.chain.VerificationResult
 import net.pwall.json.schema.JSONSchema
 import net.pwall.json.schema.parser.Parser
@@ -14,20 +15,21 @@ actual class DefaultSchemaValidationService : SchemaValidationService {
     private val schema: JSONSchema = loadSchema()
 
     override fun validate(cbor: ByteArray, verificationResult: VerificationResult) {
-        try {
-            val decoded = CBORObject.DecodeFromBytes(cbor)
-            val json = ByteArrayOutputStream().let {
-                decoded.WriteJSONTo(it)
-                it.toString()
-            }
-            val result = schema.validateBasic(json)
-            result.errors?.let { error ->
-                if (error.isNotEmpty()) {
-                    throw Throwable("Data does not follow schema: ${result.errors?.map { "${it.error}: ${it.keywordLocation}, ${it.instanceLocation}" }}")
-                }
-            }
-        } catch (t: Throwable) {
-            throw t.also { verificationResult.error = Error.CBOR_DESERIALIZATION_FAILED }
+        val decoded = try {
+            CBORObject.DecodeFromBytes(cbor)
+        } catch (e: Throwable) {
+            throw VerificationException(Error.CBOR_DESERIALIZATION_FAILED, e. message, e)
+        }
+
+        val json = ByteArrayOutputStream().let {
+            decoded.WriteJSONTo(it)
+            it.toString()
+        }
+
+        val result = schema.validateBasic(json)
+        result.errors?.takeIf { it.isNotEmpty() }?.let { errors ->
+            val errorString = errors.map { "Field ${it.instanceLocation}: ${it.error} (${it.keywordLocation})" }.joinToString("; ")
+            throw VerificationException(Error.CBOR_DESERIALIZATION_FAILED, "Data does not follow schema: $errorString")
         }
     }
 

--- a/src/jvmMain/kotlin/ehn/techiop/hcert/kotlin/chain/impl/FileBasedCryptoService.kt
+++ b/src/jvmMain/kotlin/ehn/techiop/hcert/kotlin/chain/impl/FileBasedCryptoService.kt
@@ -2,6 +2,7 @@ package ehn.techiop.hcert.kotlin.chain.impl
 
 import ehn.techiop.hcert.kotlin.chain.CryptoService
 import ehn.techiop.hcert.kotlin.chain.Error
+import ehn.techiop.hcert.kotlin.chain.VerificationException
 import ehn.techiop.hcert.kotlin.chain.VerificationResult
 import ehn.techiop.hcert.kotlin.crypto.CertificateAdapter
 import ehn.techiop.hcert.kotlin.crypto.CoseHeaderKeys
@@ -64,9 +65,9 @@ actual class FileBasedCryptoService actual constructor(pemEncodedPrivateKey: Str
     override fun getCborSigningKey() = JvmPrivKey(privateKey)
 
     override fun getCborVerificationKey(kid: ByteArray, verificationResult: VerificationResult): PubKey {
-        if (!(keyId contentEquals kid)) throw IllegalArgumentException("kid not known: $kid").also {
-            verificationResult.error = Error.KEY_NOT_IN_TRUST_LIST
-        }
+        if (!(keyId contentEquals kid))
+            throw VerificationException(Error.KEY_NOT_IN_TRUST_LIST, "kid not known: $kid")
+
         verificationResult.setCertificateData(certificate)
         return JvmPubKey(publicKey)
     }


### PR DESCRIPTION
We should differentiate two cases:
- a verification error (e.g. decoding error, invalid signature, data not conforming to schema, kid not found in trust list, etc.)
- a general error occurred during verification (e.g. connection error when downloading a trust list, error accessing disk, out of memory, etc.)

In the first case, it does not make sense for the library client to retry the verification (for that particular hcert), since the hcert is most probably invalid.

In the second case, the problem most likely does not have to do with that hcert, and retrying could make sense. Also, in general, it could make sense to try to apply some corrective action, send an alert to an operator, etc.

Therefore there is the need to deal with both cases in different ways. This commit solves this problem by using a (new) VerificationException to propagate the errors belonging to the first use case. For the second use case, the original exception is simply propagated to the application code (who can know better than us what to do with such an exception).

Also a VerificationResult.errorMessage field has been added containing a more detailed message describing the error.