### PR TITLE
Return verification error details

### DIFF
--- a/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/Chain.kt
+++ b/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/Chain.kt
@@ -77,6 +77,7 @@ class Chain(
             eudgc = higherOrderValidationService.validate(schemaValidated, verificationResult)
         } catch (e: VerificationException) {
             verificationResult.error = e.error
+            verificationResult.errorDetails = e.details
             Napier.w(
                 message = e.message ?: "Decode Chain error",
                 throwable = if (globalLogLevel == Napier.Level.VERBOSE) e else null,

--- a/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/VerificationException.kt
+++ b/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/VerificationException.kt
@@ -3,5 +3,6 @@ package ehn.techiop.hcert.kotlin.chain
 class VerificationException(
     val error: Error,
     message: String? = null,
-    cause: Throwable? = null
+    cause: Throwable? = null,
+    val details: Map<String, String>? = null
 ) : Exception(message, cause)

--- a/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/VerificationResult.kt
+++ b/src/commonMain/kotlin/ehn/techiop/hcert/kotlin/chain/VerificationResult.kt
@@ -59,6 +59,11 @@ class VerificationResult {
      */
     var error: Error? = null
 
+    /**
+     * Holds details about the error, if any occurred and relevant details are available
+     */
+    var errorDetails: Map<String, String>? = null
+
     override fun toString(): String {
         return "VerificationResult(" +
                 "expirationTime=$expirationTime, " +
@@ -70,6 +75,7 @@ class VerificationResult {
                 "certificateSubjectCountry=$certificateSubjectCountry, " +
                 "content=$content, " +
                 "error=$error, " +
+                "errorDetails=$errorDetails" +
                 ")"
     }
 


### PR DESCRIPTION
For certain verification errors (initially, CWT_EXPIRED), return additional information in the form of key-value pairs.

The purpose of this is allowing the client code of the library to obtain additional data about certain errors, so that it can record richer logs or process that data in some way (e.g. presenting it to a human for diagnostics).

See issue #43 for a discussion of other alternatives to provide this feature.