### PR TITLE
build: stop using the jcenter repository

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,6 @@ licenseReport {
 
 repositories {
     mavenLocal()
-    jcenter()
     mavenCentral()
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -2,5 +2,5 @@ plugins {
     `kotlin-dsl`
 }
 repositories {
-    jcenter()
+    mavenCentral()
 }


### PR DESCRIPTION
jcenter is no longer active and in read-only mode. While this wouldn't be a problem
it also times out a lot here and on GHA:

> Could not resolve io.github.aakira:napier:1.5.0.
    > Could not get resource 'https://jcenter.bintray.com/io/github/aakira/napier/1.5.0/napier-1.5.0.pom'.
    > Could not GET 'https://jcenter.bintray.com/io/github/aakira/napier/1.5.0/napier-1.5.0.pom'.
        > Read timed out

So get rid of it and use mavenCentral instead.