### PR TITLE
JsDateSerializer: serialize the full date including time and tz info

### DIFF
--- a/src/jsMain/kotlin/ehn/techiop/hcert/kotlin/data/JsDateSerializer.kt
+++ b/src/jsMain/kotlin/ehn/techiop/hcert/kotlin/data/JsDateSerializer.kt
@@ -16,11 +16,11 @@ object JsDateSerializer : KSerializer<Date> {
 
     override fun deserialize(decoder: Decoder): Date {
         val value = decoder.decodeString()
-        return Date(value.substringBefore("T"))
+        return Date(value)
     }
 
     override fun serialize(encoder: Encoder, value: Date) {
-        encoder.encodeString(value.toISOString().substringBefore("T"))
+        encoder.encodeString(value.toISOString())
     }
 }
 


### PR DESCRIPTION
JsDateSerializer is used for serializing the dates in the metaInformation
property of the validation result. Up until now it ignored any time
and timezone information which resulted in loss of information when
using the API from javascript.

Make it de/serialize the full ISO date string instead so no
information is lost.

Fixes #61